### PR TITLE
Notify when shared directories are mounted

### DIFF
--- a/tasks/client.yaml
+++ b/tasks/client.yaml
@@ -24,3 +24,4 @@
         dump: "{{ item.dump | default(omit) }}"
         passno: "{{ item.passno | default(omit) }}"
       with_items: "{{ nfs_client_imports }}"
+      notify: "nfs shared directories mounted"


### PR DESCRIPTION
This will allow parent playbooks/roles to trigger specific actions on
mount state change (with the listen directive).