### PR TITLE
Changed filter to condition

### DIFF
--- a/tasks/server.yaml
+++ b/tasks/server.yaml
@@ -11,7 +11,7 @@
 
     - name: Restart NFS server service
       service: name={{NFS_SERVICE}} state=restarted enabled=yes
-      when: nfs_exports_result|changed
+      when: nfs_exports_result is changed
 
     - name: Check if NFS server service is started
       service: name={{NFS_SERVICE}} state=started


### PR DESCRIPTION
The filter fails (with Ansible 2.9.1) with

```
fatal: [id-lnx-stud-store-01]: FAILED! => {"msg": "The conditional check 'nfs_exports_result|changed' failed. The error was: template error while templating string: no filter named 'changed'. String: {% if nfs_exports_result|changed %} True {% else %} False {% endif %}\n\nThe error appears to be in '/home/bgiger/.ansible/roles/indigo-dc.nfs/tasks/server.yaml': line 12, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Restart NFS server service\n      ^ here\n"}%
```

Changing to a condition

```
if nfs_exports_result is changed
```

fixes the error